### PR TITLE
replaces all versions of nodejs8.10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: app.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Description: Pinpoint-Connect Callback AWS Lambda function.
       MemorySize: 128

--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: app.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       CodeUri: src/
       Description: Pinpoint-Connect Callback AWS Lambda function.
       MemorySize: 128


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #2 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
